### PR TITLE
Fixed bug when extracting windows 10

### DIFF
--- a/operating_systems.go
+++ b/operating_systems.go
@@ -33,7 +33,7 @@ func normalizeOS(name string) string {
 		return "Windows 8"
 	case "6.3":
 		return "Windows 8.1"
-	case "6.4":
+	case "10.0":
 		return "Windows 10"
 	}
 	return name


### PR DESCRIPTION
Windows 10 is actually Windows NT 10.0 and not Windows NT 6.4.

Resolves: #21