### PR TITLE
Fixed bug when extracting windows 10

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -134,7 +134,7 @@ var expected = []string{
 	"Mozilla:4.0 Platform:Windows OS:Windows 8.1 Browser:Internet Explorer-7.0 Engine:Trident Bot:false Mobile:false",
 
 	// Microsoft Edge
-	"Mozilla:5.0 Platform:Windows OS:Windows NT 10.0 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:false",
+	"Mozilla:5.0 Platform:Windows OS:Windows 10 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:false",
 	"Mozilla:5.0 Platform:Windows OS:Windows Phone 10.0 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:true",
 
 	// Gecko

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -7,12 +7,12 @@ package user_agent
 import "strings"
 
 // Normalize the name of the operating system. By now, this just
-// affects to Windows.
+// affects to Windows NT.
 //
 // Returns a string containing the normalized name for the Operating System.
 func normalizeOS(name string) string {
 	sp := strings.SplitN(name, " ", 3)
-	if len(sp) != 3 {
+	if len(sp) != 3 || sp[1] != "NT" {
 		return name
 	}
 
@@ -33,7 +33,7 @@ func normalizeOS(name string) string {
 		return "Windows 8"
 	case "6.3":
 		return "Windows 8.1"
-	case "6.4":
+	case "10.0":
 		return "Windows 10"
 	}
 	return name


### PR DESCRIPTION
Windows 10 is actually Windows NT 10.0 and not Windows NT 6.4.

Resolves: #21