### PR TITLE
Improved bot recognition

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -62,6 +62,26 @@ var uastrings = []struct {
 		ua:       "Facebot",
 		expected: "Browser:Facebot Bot:true Mobile:false",
 	},
+	{
+		title:    "NutchCVS",
+		ua:       "NutchCVS/0.8-dev (Nutch; http://lucene.apache.org/nutch/bot.html; nutch-agent@lucene.apache.org)",
+		expected: "Browser:NutchCVS Bot:true Mobile:false",
+	},
+	{
+		title:    "MJ12bot",
+		ua:       "Mozilla/5.0 (compatible; MJ12bot/v1.2.4; http://www.majestic12.co.uk/bot.php?+)",
+		expected: "Mozilla:5.0 Browser:MJ12bot-v1.2.4 Bot:true Mobile:false",
+	},
+	{
+		title:    "MJ12bot",
+		ua:       "MJ12bot/v1.0.8 (http://majestic12.co.uk/bot.php?+)",
+		expected: "Browser:MJ12bot Bot:true Mobile:false",
+	},
+	{
+		title:    "AhrefsBot",
+		ua:       "Mozilla/5.0 (compatible; AhrefsBot/4.0; +http://ahrefs.com/robot/)",
+		expected: "Mozilla:5.0 Browser:AhrefsBot-4.0 Bot:true Mobile:false",
+	},
 
 	// Internet Explorer
 	{

--- a/bot.go
+++ b/bot.go
@@ -75,6 +75,8 @@ func (p *UserAgent) fixOther(sections []section) {
 	}
 }
 
+var botRegex = regexp.MustCompile("(?i)(bot|crawler|sp(i|y)der|search|worm|fetch|nutch)")
+
 // Check if we're dealing with a bot or with some weird browser. If that is the
 // case, the receiver will be modified accordingly.
 func (p *UserAgent) checkBot(sections []section) {
@@ -83,9 +85,8 @@ func (p *UserAgent) checkBot(sections []section) {
 	if len(sections) == 1 && sections[0].name != "Mozilla" {
 		p.mozilla = ""
 
-		// Check whether the name has some suspicious "bot" in his name.
-		reg, _ := regexp.Compile("(?i)bot")
-		if reg.Match([]byte(sections[0].name)) {
+		// Check whether the name has some suspicious "bot" or "crawler" in his name.
+		if botRegex.Match([]byte(sections[0].name)) {
 			p.setSimple(sections[0].name, "", true)
 			return
 		}


### PR DESCRIPTION
Improved from (212/286 crawlers 74.13%) to (225/286 crawlers 78.67%) tested with https://github.com/crackcomm/crawler-user-agents/blob/master/tests/main.go

Simply more keywords in [bot regex](https://github.com/mssola/user_agent/pull/26/files#diff-e36ad8cc9750c02d601edfe9e03842ddR78).

I'm aware that for example `nutch` maybe not wanted there but I simply had no time to fix the parser and I wanted to recognize important bots for me. I can use it from other repo (thanks:) so Im just proposing it for you as a feature. Close it if You don't want it so I can remove repo.