### PR TITLE
Add Chromium support and Ubuntu specific tests

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -174,6 +174,11 @@ var uastrings = []struct {
 		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Firefox-17.0 Engine:Gecko-20100101 Bot:false Mobile:false",
 	},
 	{
+		title:    "FirefoxLinux - Ubuntu V50",
+		ua:       "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:50.0) Gecko/20100101 Firefox/50.0",
+		expected: "Mozilla:5.0 Platform:X11 OS:Ubuntu Browser:Firefox-50.0 Engine:Gecko-20100101 Bot:false Mobile:false",
+	},
+	{
 		title:    "FirefoxWin",
 		ua:       "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14",
 		expected: "Mozilla:5.0 Platform:Windows OS:Windows XP Localization:en-US Browser:Firefox-2.0.0.14 Engine:Gecko-20080404 Bot:false Mobile:false",
@@ -266,6 +271,11 @@ var uastrings = []struct {
 		expected: "Platform:X11 OS:Linux x86_64 Browser:Opera-9.80 Engine:Presto-2.12.388 Bot:false Mobile:false",
 	},
 	{
+		title:    "OperaLinux - Ubuntu V41",
+		ua:       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36 OPR/41.0.2353.69",
+		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Opera-41.0.2353.69 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
+	},
+	{
 		title:    "OperaAndroid",
 		ua:       "Opera/9.80 (Android 4.2.1; Linux; Opera Mobi/ADR-1212030829) Presto/2.11.355 Version/12.10",
 		expected: "Platform:Android 4.2.1 OS:Linux Browser:Opera-9.80 Engine:Presto-2.11.355 Bot:false Mobile:true",
@@ -328,6 +338,11 @@ var uastrings = []struct {
 		title:    "ChromeLinux",
 		ua:       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.97 Safari/537.11",
 		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Chrome-23.0.1271.97 Engine:AppleWebKit-537.11 Bot:false Mobile:false",
+	},
+	{
+		title:    "ChromeLinux - Ubuntu V55",
+		ua:       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.75 Safari/537.36",
+		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Chrome-55.0.2883.75 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
 	},
 	{
 		title:    "ChromeWin7",
@@ -428,6 +443,16 @@ var uastrings = []struct {
 		title:    "SafariOnSymbian",
 		ua:       "Mozilla/5.0 (SymbianOS/9.1; U; [en-us]) AppleWebKit/413 (KHTML, like Gecko) Safari/413",
 		expected: "Mozilla:5.0 Platform:Symbian OS:SymbianOS/9.1 Browser:Symbian-413 Engine:AppleWebKit-413 Bot:false Mobile:true",
+	},
+	{
+		title:    "Chromium - Ubuntu V49",
+		ua:       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/49.0.2623.108 Chrome/49.0.2623.108 Safari/537.36",
+		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Chromium-49.0.2623.108 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
+	},
+	{
+		title:    "Chromium - Ubuntu V55",
+		ua:       "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/53.0.2785.143 Chrome/53.0.2785.143 Safari/537.36",
+		expected: "Mozilla:5.0 Platform:X11 OS:Linux x86_64 Browser:Chromium-53.0.2785.143 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
 	},
 
 	// Dalvik

--- a/browser.go
+++ b/browser.go
@@ -51,7 +51,13 @@ func (p *UserAgent) detectBrowser(sections []section) {
 		p.browser.Engine = engine.name
 		p.browser.EngineVersion = engine.version
 		if slen > 2 {
-			p.browser.Version = sections[2].version
+			sectionIndex := 2
+			// The version after the engine comment is empty on e.g. Ubuntu
+			// platforms so if this is the case, let's use the next in line.
+			if sections[2].version == "" && slen > 3 {
+				sectionIndex = 3
+			}
+			p.browser.Version = sections[sectionIndex].version
 			if engine.name == "AppleWebKit" {
 				switch sections[slen-1].name {
 				case "Edge":
@@ -63,8 +69,10 @@ func (p *UserAgent) detectBrowser(sections []section) {
 					p.browser.Name = "Opera"
 					p.browser.Version = sections[slen-1].version
 				default:
-					if sections[2].name == "Chrome" {
+					if sections[sectionIndex].name == "Chrome" {
 						p.browser.Name = "Chrome"
+					} else if sections[sectionIndex].name == "Chromium" {
+						p.browser.Name = "Chromium"
 					} else {
 						p.browser.Name = "Safari"
 					}

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -126,7 +126,9 @@ func gecko(p *UserAgent, comment []string) {
 				}
 			}
 		}
-		if len(comment) > 3 {
+		// Only parse 4th comment as localization if it doesn't start with rv:.
+		// For example Firefox on Ubuntu contains "rv:XX.X" in this field.
+		if len(comment) > 3 && !strings.HasPrefix(comment[3], "rv:") {
 			p.localization = comment[3]
 		}
 	}


### PR DESCRIPTION
Thanks for providing this library! :smiley: 

This PR adds support for the Chromium user agent string and adds user agent tests for the latest version of all major browsers available on Ubuntu.

Fixes:
- Ignore revision field for localization (e.g. rv:50.0)
- Ignore browser name parameter without version (e.g. "Ubuntu")

Fixes #27