### PR TITLE
Detect updated UA for Googlebot

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -25,8 +25,13 @@ var uastrings = []struct {
 		expected: "Mozilla:5.0 Browser:Googlebot-2.1 Bot:true Mobile:false",
 	},
 	{
-		title:    "GoogleBotSmartphone",
+		title:    "GoogleBotSmartphone (iPhone)",
 		ua:       "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+		expected: "Mozilla:5.0 Browser:Googlebot-2.1 Bot:true Mobile:true",
+	},
+	{
+		title:    "GoogleBotSmartphone (Android)",
+		ua:       "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
 		expected: "Mozilla:5.0 Browser:Googlebot-2.1 Bot:true Mobile:true",
 	},
 	{

--- a/all_test.go
+++ b/all_test.go
@@ -561,18 +561,20 @@ func beautify(ua *UserAgent) (s string) {
 // The test suite.
 func TestUserAgent(t *testing.T) {
 	for _, tt := range uastrings {
-		ua := New(tt.ua)
-		got := beautify(ua)
-		if tt.expected != got {
-			t.Errorf("\nTest     %v\ngot:     %q\nexpected %q\n", tt.title, got, tt.expected)
-		}
-
-		if tt.expectedOS != nil {
-			gotOSInfo := ua.OSInfo()
-			if !reflect.DeepEqual(tt.expectedOS, &gotOSInfo) {
-				t.Errorf("\nTest     %v\ngot:     %#v\nexpected %#v\n", tt.title, gotOSInfo, tt.expectedOS)
+		t.Run(tt.title, func(t *testing.T) {
+			ua := New(tt.ua)
+			got := beautify(ua)
+			if tt.expected != got {
+				t.Errorf("\nTest     %v\ngot:     %q\nexpected %q\n", tt.title, got, tt.expected)
 			}
-		}
+
+			if tt.expectedOS != nil {
+				gotOSInfo := ua.OSInfo()
+				if !reflect.DeepEqual(tt.expectedOS, &gotOSInfo) {
+					t.Errorf("\nTest     %v\ngot:     %#v\nexpected %#v\n", tt.title, gotOSInfo, tt.expectedOS)
+				}
+			}
+		})
 	}
 }
 

--- a/all_test.go
+++ b/all_test.go
@@ -566,20 +566,18 @@ func beautify(ua *UserAgent) (s string) {
 // The test suite.
 func TestUserAgent(t *testing.T) {
 	for _, tt := range uastrings {
-		t.Run(tt.title, func(t *testing.T) {
-			ua := New(tt.ua)
-			got := beautify(ua)
-			if tt.expected != got {
-				t.Errorf("\nTest     %v\ngot:     %q\nexpected %q\n", tt.title, got, tt.expected)
-			}
+		ua := New(tt.ua)
+		got := beautify(ua)
+		if tt.expected != got {
+			t.Errorf("\nTest     %v\ngot:     %q\nexpected %q\n", tt.title, got, tt.expected)
+		}
 
-			if tt.expectedOS != nil {
-				gotOSInfo := ua.OSInfo()
-				if !reflect.DeepEqual(tt.expectedOS, &gotOSInfo) {
-					t.Errorf("\nTest     %v\ngot:     %#v\nexpected %#v\n", tt.title, gotOSInfo, tt.expectedOS)
-				}
+		if tt.expectedOS != nil {
+			gotOSInfo := ua.OSInfo()
+			if !reflect.DeepEqual(tt.expectedOS, &gotOSInfo) {
+				t.Errorf("\nTest     %v\ngot:     %#v\nexpected %#v\n", tt.title, gotOSInfo, tt.expectedOS)
 			}
-		})
+		}
 	}
 }
 

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -88,8 +88,7 @@ func webkit(p *UserAgent, comment []string) {
 		}
 		if len(comment) > 3 {
 			p.localization = comment[3]
-		}
-		if len(comment) == 3 {
+		} else if len(comment) == 3 {
 			_ = p.googleBot()
 		}
 	} else if len(comment) > 0 {

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -89,6 +89,9 @@ func webkit(p *UserAgent, comment []string) {
 		if len(comment) > 3 {
 			p.localization = comment[3]
 		}
+		if len(comment) == 3 {
+			_ = p.googleBot()
+		}
 	} else if len(comment) > 0 {
 		if len(comment) > 3 {
 			p.localization = comment[3]


### PR DESCRIPTION
Google announced they changed UA for Googlebot.

* [Official Google Webmaster Central Blog: Updating the smartphone user-agent of Googlebot](https://webmasters.googleblog.com/2016/03/updating-smartphone-user-agent-of.html)

The most significant change is that the new one has `Android` instead of `iPhone`.  This patch adds the detection by calling the `p.googleBot()` method accordingly.

----

In addition to that, this PR includes diff to use subtest feature.  With this, `go test -v` shows test titles neatly and makes easy to find failed ones.

----

updated

hmm... Test has failed due to subtest feature.  But the old Go's (<1.7) may be removed, I think.