### PR TITLE
Fix mobile Firefox on Android Nougat

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -229,6 +229,11 @@ var uastrings = []struct {
 		expected: "Mozilla:5.0 Platform:Mobile OS:Android Browser:Firefox-17.0 Engine:Gecko-17.0 Bot:false Mobile:true",
 	},
 	{
+		title:    "AndroidFirefoxNougat",
+		ua:       "Mozilla/5.0 (Android 7.0; Mobile; rv:60.0) Gecko/60.0 Firefox/60.0",
+		expected: "Mozilla:5.0 Platform:Mobile OS:Android 7.0 Browser:Firefox-60.0 Engine:Gecko-60.0 Bot:false Mobile:true",
+	},
+	{
 		title:      "AndroidFirefoxTablet",
 		ua:         "Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0",
 		expected:   "Mozilla:5.0 Platform:Tablet OS:Android Browser:Firefox-26.0 Engine:Gecko-26.0 Bot:false Mobile:true",

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -129,7 +129,7 @@ func gecko(p *UserAgent, comment []string) {
 				p.os = normalizeOS(comment[1])
 			}
 		} else {
-			if p.platform == "Android" {
+			if strings.Contains(p.platform, "Android") {
 				p.mobile = true
 				p.platform, p.os = normalizeOS(comment[1]), p.platform
 			} else if comment[0] == "Mobile" || comment[0] == "Tablet" {


### PR DESCRIPTION
This commit fixes a small bug identifying mobile Firefox running on Android OS versions that report their version number inline.

There is a test case included that gives an example and the tests are passing.