### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -134,13 +134,13 @@ func (p *UserAgent) detectBrowser(sections []section) {
 	}
 }
 
-// Returns two strings. The first string is the name of the engine and the
+// Engine returns two strings. The first string is the name of the engine and the
 // second one is the version of the engine.
 func (p *UserAgent) Engine() (string, string) {
 	return p.browser.Engine, p.browser.EngineVersion
 }
 
-// Returns two strings. The first string is the name of the browser and the
+// Browser returns two strings. The first string is the name of the browser and the
 // second one is the version of the browser.
 func (p *UserAgent) Browser() (string, string) {
 	return p.browser.Name, p.browser.Version

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -282,17 +282,17 @@ func (p *UserAgent) detectOS(s section) {
 	}
 }
 
-// Returns a string containing the platform..
+// Platform returns a string containing the platform..
 func (p *UserAgent) Platform() string {
 	return p.platform
 }
 
-// Returns a string containing the name of the Operating System.
+// OS returns a string containing the name of the Operating System.
 func (p *UserAgent) OS() string {
 	return p.os
 }
 
-// Returns a string containing the localization.
+// Localization returns a string containing the localization.
 func (p *UserAgent) Localization() string {
 	return p.localization
 }
@@ -325,7 +325,7 @@ func osName(osSplit []string) (name, version string) {
 	return name, version
 }
 
-// Returns combined information for the operating system.
+// OSInfo returns combined information for the operating system.
 func (p *UserAgent) OSInfo() OSInfo {
 	// Special case for iPhone weirdness
 	os := strings.Replace(p.os, "like Mac OS X", "", 1)

--- a/user_agent.go
+++ b/user_agent.go
@@ -164,23 +164,23 @@ func (p *UserAgent) Parse(ua string) {
 	}
 }
 
-// Returns the mozilla version (it's how the User Agent string begins:
+// Mozilla returns the mozilla version (it's how the User Agent string begins:
 // "Mozilla/5.0 ...", unless we're dealing with Opera, of course).
 func (p *UserAgent) Mozilla() string {
 	return p.mozilla
 }
 
-// Returns true if it's a bot, false otherwise.
+// Bot returns true if it's a bot, false otherwise.
 func (p *UserAgent) Bot() bool {
 	return p.bot
 }
 
-// Returns true if it's a mobile device, false otherwise.
+// Mobile returns true if it's a mobile device, false otherwise.
 func (p *UserAgent) Mobile() bool {
 	return p.mobile
 }
 
-// Returns the original given user agent.
+// UA returns the original given user agent.
 func (p *UserAgent) UA() string {
 	return p.ua
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?