### PR TITLE
Detect Electron

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -541,6 +541,11 @@ var uastrings = []struct {
 		ua:       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4",
 		expected: "Mozilla:5.0 Platform:iPhone OS:CPU iPhone OS 8_3 like Mac OS X Browser:Firefox-1.0 Engine:AppleWebKit-600.1.4 Bot:false Mobile:true",
 	},
+	{
+		title:    "Electron",
+		ua:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CozyDrive/3.17.0  Chrome/73.0.3683.119 Electron/5.0.0 Safari/537.36",
+		expected: "Mozilla:5.0 Platform:Windows OS:Windows 10 Browser:Electron-5.0.0 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
+	},
 
 	// Dalvik
 	{

--- a/browser.go
+++ b/browser.go
@@ -74,15 +74,21 @@ func (p *UserAgent) detectBrowser(sections []section) {
 						p.browser.Name = "YaBrowser"
 						p.browser.Version = sections[slen-3].version
 					default:
-						switch sections[sectionIndex].name {
-						case "Chrome", "CriOS":
-							p.browser.Name = "Chrome"
-						case "Chromium":
-							p.browser.Name = "Chromium"
-						case "FxiOS":
-							p.browser.Name = "Firefox"
+						switch sections[slen-2].name {
+						case "Electron":
+							p.browser.Name = "Electron"
+							p.browser.Version = sections[slen-2].version
 						default:
-							p.browser.Name = "Safari"
+							switch sections[sectionIndex].name {
+							case "Chrome", "CriOS":
+								p.browser.Name = "Chrome"
+							case "Chromium":
+								p.browser.Name = "Chromium"
+							case "FxiOS":
+								p.browser.Name = "Firefox"
+							default:
+								p.browser.Name = "Safari"
+							}
 						}
 					}
 					// It's possible the google-bot emulates these now


### PR DESCRIPTION
Electron was seen as Safari, even if it is based on Chrome. With this commit, is is now detected as Electron.