### PR TITLE
Added support for both http and https site urls

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -104,6 +104,11 @@ var uastrings = []struct {
 		ua:       "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)",
 		expected: "Mozilla:5.0 Browser:AdsBot-Google-Mobile Bot:true Mobile:true",
 	},
+	{
+		title:    "APIs-Google",
+		ua:       "APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)",
+		expected: "Browser:APIs-Google Bot:true Mobile:false",
+	},
 
 	// Internet Explorer
 	{

--- a/bot.go
+++ b/bot.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var botFromSiteRegexp = regexp.MustCompile("http://.+\\.\\w+")
+var botFromSiteRegexp = regexp.MustCompile("http[s]?://.+\\.\\w+")
 
 // Get the name of the bot from the website that may be in the given comment. If
 // there is no website in the comment, then an empty string is returned.


### PR DESCRIPTION
Some bots provide non `http://` urls in the UserAgent header e.g. APIs-Google bot. This PR adds support for both protocols in the url.