### PR TITLE
Added Detection of Chromium Edge on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix detection of Firefox on iPad.
 - Fix detection of Linux ARM-based Android.
+- Add detection of Chromium Edge on Windows.
 
 ## 0.5.2
 

--- a/all_test.go
+++ b/all_test.go
@@ -210,6 +210,14 @@ var uastrings = []struct {
 		expected: "Mozilla:5.0 Platform:Windows OS:Windows Phone 10.0 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:true",
 	},
 
+	// Microsoft Chromium Edge
+	{
+		title:      "EdgeDesktop",
+		ua:         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36 Edg/83.0.478.37",
+		expected:   "Mozilla:5.0 Platform:Windows OS:Windows 10 Browser:Edge-83.0.478.37 Engine:AppleWebKit-537.36 Bot:false Mobile:false",
+		expectedOS: &OSInfo{"Windows 10", "Windows", "10"},
+	},
+
 	// Gecko
 	{
 		title:      "FirefoxMac",

--- a/browser.go
+++ b/browser.go
@@ -59,12 +59,26 @@ func (p *UserAgent) detectBrowser(sections []section) {
 			}
 			p.browser.Version = sections[sectionIndex].version
 			if engine.name == "AppleWebKit" {
+				for _, comment := range engine.comment {
+					if len(comment) > 5 &&
+						(strings.HasPrefix(comment, "Googlebot") || strings.HasPrefix(comment, "bingbot")) {
+						p.undecided = true
+						break
+					}
+				}
 				switch sections[slen-1].name {
 				case "Edge":
 					p.browser.Name = "Edge"
 					p.browser.Version = sections[slen-1].version
 					p.browser.Engine = "EdgeHTML"
 					p.browser.EngineVersion = ""
+				case "Edg":
+					if p.undecided != true {
+						p.browser.Name = "Edge"
+						p.browser.Version = sections[slen-1].version
+						p.browser.Engine = "AppleWebKit"
+						p.browser.EngineVersion = sections[slen-2].version
+					}
 				case "OPR":
 					p.browser.Name = "Opera"
 					p.browser.Version = sections[slen-1].version


### PR DESCRIPTION
Moved bingbot and googlebot detection to beginning of AppleWebKit section to avoid false-positive for Chromium Edge from 'Edg' in bingbot.
Added case 'Edg' to account for Chromium Edge on Windows.
Added test case for Chromium Edge on Windows.
Updated Changelong.

Signed-off-by: Dan Hammer <daniel.m.hammer@gmail.com>

Fixes #69 

Provide a general description of the changes in your pull request. If this pull request fixes a known issue, please tag it as well (e.g.: `Fixes #1`).

Before submitting a PR make sure the following things have been done (and denote this by checking the relevant checkboxes):

- [X] The commits are consistent with the [contribution guidelines](../CONTRIBUTING.md).
- [X] You've added tests (if possible) to cover your change(s).
- [X] All tests and style checkers are passing (`make ci`).
- [X] You've updated the [changelog](../CHANGELOG.md).
- [X] You've updated the [readme](../README.md) (if relevant).

Thanks for contributing to user_agent!
