### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 git:
   depth: false
 
+arch:
+  - amd64
+  - ppc64le
+
 go:
   - 1.4.x
   - 1.5.x
@@ -20,6 +24,9 @@ go:
 matrix:
   allow_failures:
     - go: tip
+  exclude:
+    - go: 1.4.x
+      arch: ppc64le
 
 before_install:
   - chmod +x ./ci/install.sh && ./ci/install.sh


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.
Travis-ci Log: https://travis-ci.com/github/dthadi3/user_agent/builds/210054682

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra